### PR TITLE
fix typo

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -168,7 +168,7 @@ return [
         Collective\Html\HtmlServiceProvider::class,
         Laracasts\Flash\FlashServiceProvider::class,
         \InfyOm\Generator\InfyOmGeneratorServiceProvider::class,
-        \InfyOm\CoreUITemplates\COreUITemplatesServiceProvider::class,
+        \InfyOm\CoreUITemplates\CoreUITemplatesServiceProvider::class,
         Yajra\DataTables\DataTablesServiceProvider::class,
         Yajra\DataTables\HtmlServiceProvider::class,
         Yajra\DataTables\ButtonsServiceProvider::class,


### PR DESCRIPTION
In Line 171

Composer install logs

```
  In ProviderRepository.php line 208:
                                                                                  
         Class 'InfyOm\CoreUITemplates\COreUITemplatesServiceProvider' not found  
                                                                                  
       
       Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
 !     WARNING: There was a class not found error in your code
 !     ERROR: Dependency installation failed!
 !     
 !     The 'composer install' process failed with an error. The cause
 !     may be the download or installation of packages, or a pre- or
 !     post-install hook (e.g. a 'post-install-cmd' item in 'scripts')
 !     in your 'composer.json'.
 !     
 !     Typical error cases are out-of-date or missing parts of code,
 !     timeouts when making external connections, or memory limits.
```