### PR TITLE
fix: Change @yield to @stack at layouts/app.blade.php - Laravel 6.0

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -98,6 +98,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/js/bootstrap-datetimepicker.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@coreui/coreui@2.1.16/dist/js/coreui.min.js"></script>
-@yield('scripts')
+@stack('scripts')
 
 </html>


### PR DESCRIPTION
I was clone this repo for Laravel 6.0 and I found an issue that my Datatables not working.
after investigated I found Coreui for Laravel 6.0 still used @yield

- https://laravel.com/docs/5.8/blade#stacks